### PR TITLE
Fix Wrong sign appearing when clicking on download convention button

### DIFF
--- a/res/css/index.scss
+++ b/res/css/index.scss
@@ -17,3 +17,6 @@ ul li {
 h1, h2, h3, h4, h5, h6 {
   color: $color-theme-blue;
 }
+a.tc_TestYourEmail_link {
+    cursor: pointer;
+}


### PR DESCRIPTION
Wrong sign appearing when clicking on download convention button
Issue #58