### PR TITLE
Add a Contact section, with the contact email visible, to avoid relying on mailto links

### DIFF
--- a/src/components/bars/TopBar.js
+++ b/src/components/bars/TopBar.js
@@ -62,10 +62,8 @@ class TopBar extends Component {
 											</a>
 										</li>
 										<li>
-											<a class="fr-link fr-fi-external-link-line"
-												href={'mailto:' + t('links.contact')}
-												target="_blank"
-												rel="noreferer noopener"
+											<a class="fr-link"
+												href="#contact"
 												data-probe-name="contact"
 												onClick={this._hookProbe}>
 													Contact

--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -4,6 +4,7 @@ import BottomBar from "components/bars/BottomBar";
 import WelcomePanel from "./panels/WelcomePanel";
 import MainPanel from "pages/home/panels/MainPanel";
 import JoinUsPanel from "pages/home/panels/JoinUsPanel";
+import ContactPanel from "pages/home/panels/ContactPanel";
 import "styles/pages/home/Home.scss";
 
 class Home extends Component {
@@ -15,6 +16,7 @@ class Home extends Component {
 				<WelcomePanel/>
 				<JoinUsPanel/>
 				<MainPanel/>
+				<ContactPanel/>
 				<BottomBar/>
 			</div>
 		);

--- a/src/pages/home/panels/ContactPanel.js
+++ b/src/pages/home/panels/ContactPanel.js
@@ -1,0 +1,31 @@
+import { Component } from 'react';
+import Container from "@mui/material/Container";
+import { t } from "react-i18nify";
+
+class ContactPanel extends Component {
+	render() {
+		return (
+			<Container maxWidth={false} disableGutters={true}>
+				<div className="tc_ContactPanel" id="contact">
+					<Container maxWidth="lg">
+						<div class="fr-callout fr-mb-4w">
+							<p class="fr-callout__title">Contactez-nous</p>
+							<p class="fr-callout__text">
+							  Pour toute question, vous pouvez nous envoyer un email à <b>{t('links.contact')}</b>.
+							</p>
+							<a class="fr-btn"
+							   href={'mailto:' + t('links.contact')}
+								 target="_blank"
+								 rel="noreferer noopener"
+								 data-probe-name="contact">
+								Ecrivez-nous
+							</a>
+						</div>
+					</Container>
+				</div>
+			</Container>
+		);
+	}
+}
+
+export default ContactPanel;


### PR DESCRIPTION
Fixing https://github.com/tchapgouv/tchap-landing-page/issues/52

For the home page, the "Contact" link in the topbar is a mailto link. This PR changes it to point to a "Contact" section at the bottom of the page, where the users can copy the email if they can't use the mailto link.

The "Contact" section is a callout (mise en avant) from the design system : https://gouvfr.atlassian.net/wiki/spaces/DB/pages/222331196/Mise+en+avant+-+Call+out#Personnalisation
