### PR TITLE
Ajout de l'adresse support au bloc contact

### DIFF
--- a/res/locales/fr.json
+++ b/res/locales/fr.json
@@ -2,6 +2,7 @@
   "fr": {
     "links": {
       "contact": "tchap@beta.gouv.fr",
+      "support": "support@tchap.beta.gouv.fr",
       "prise-en-main": "/prise-en-main",
       "faq": "/faq"
     }

--- a/src/pages/home/panels/ContactPanel.js
+++ b/src/pages/home/panels/ContactPanel.js
@@ -11,7 +11,8 @@ class ContactPanel extends Component {
 						<div class="fr-callout fr-mb-4w">
 							<p class="fr-callout__title">Contactez-nous</p>
 							<p class="fr-callout__text">
-							  Pour toute question, vous pouvez nous envoyer un email à <b>{t('links.contact')}</b>.
+								Le support de Tchap est joignable à l'adresse <b>support@tchap.beta.gouv.fr</b>. 
+							  	Pour toute autre question, vous pouvez nous envoyer un email à <b>{t('links.contact')}</b>.
 							</p>
 							<a class="fr-btn"
 							   href={'mailto:' + t('links.contact')}

--- a/src/pages/home/panels/ContactPanel.js
+++ b/src/pages/home/panels/ContactPanel.js
@@ -11,10 +11,18 @@ class ContactPanel extends Component {
 						<div class="fr-callout fr-mb-4w">
 							<p class="fr-callout__title">Contactez-nous</p>
 							<p class="fr-callout__text">
-								<div Tchap ne fonctionne pas normalement ? > 
-									<div Vous avez besoin d'aide pour vous en servir ?>
-									<div Le support est joignable à l'adresse <b>support@tchap.beta.gouv.fr</b>.>
-							  	<div Pour toute sollicitation plus générale, vous pouvez contacter l'équipe à <b>{t('links.contact')}</b>.>
+								<div>
+									Tchap ne fonctionne pas normalement ?
+								</div>
+								<div>
+									Vous avez besoin d'aide pour vous en servir ?
+								</div>
+								<div>
+									Le support est joignable à l'adresse <b>support@tchap.beta.gouv.fr</b>.
+								</div>
+							  <div>
+									Pour toute sollicitation plus générale, vous pouvez contacter l'équipe à <b>{t('links.contact')}</b>.
+								</div>
 							</p>
 							<a class="fr-btn"
 							   href={'mailto:' + t('links.contact')}

--- a/src/pages/home/panels/ContactPanel.js
+++ b/src/pages/home/panels/ContactPanel.js
@@ -11,8 +11,10 @@ class ContactPanel extends Component {
 						<div class="fr-callout fr-mb-4w">
 							<p class="fr-callout__title">Contactez-nous</p>
 							<p class="fr-callout__text">
-								Le support de Tchap est joignable à l'adresse <b>support@tchap.beta.gouv.fr</b>. 
-							  	Pour toute autre question, vous pouvez nous envoyer un email à <b>{t('links.contact')}</b>.
+								<div Tchap ne fonctionne pas normalement ? > 
+									<div Vous avez besoin d'aide pour vous en servir ?>
+									<div Le support est joignable à l'adresse <b>support@tchap.beta.gouv.fr</b>.>
+							  	<div Pour toute sollicitation plus générale, vous pouvez contacter l'équipe à <b>{t('links.contact')}</b>.>
 							</p>
 							<a class="fr-btn"
 							   href={'mailto:' + t('links.contact')}

--- a/src/pages/home/panels/ContactPanel.js
+++ b/src/pages/home/panels/ContactPanel.js
@@ -18,7 +18,7 @@ class ContactPanel extends Component {
 									Vous avez besoin d'aide pour vous en servir ?
 								</div>
 								<div>
-									Le support est joignable à l'adresse <b>support@tchap.beta.gouv.fr</b>.
+									Le support est joignable à l'adresse <b>{t('links.support')}</b>.
 								</div>
 							  <div>
 									Pour toute sollicitation plus générale, vous pouvez contacter l'équipe à <b>{t('links.contact')}</b>.


### PR DESCRIPTION
Je ne sais pas si j'ai bien géré la mise en forme dans le code  :))

Le support de Tchap est joignable à l'adresse <b>support@tchap.beta.gouv.fr</b>. 
Pour toute autre question, vous pouvez nous envoyer un email à <b>{t('links.contact')}</b>.