### PR TITLE
Fix mailto

### DIFF
--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -168,8 +168,8 @@ class FaqComponent extends Component {
 										<li>Les collectivités</li>
 										<li>Autres personnes morales de droit public comme les Groupements d'Intérêt Public (GIP)</li>
 									</ul>
-									<div>Vous pouvez vérifier si votre e-mail professionnel est bien reconnu par Tchap  <GenericLink className="tc_FaqComponent_link" to={"/#joinUs"}>ici</GenericLink>.</div>
-									<div className="tc_text_nl">Si votre e-mail professionnel n'est pas reconnu par Tchap, vous pouvez en faire la demande en envoyant  <GenericLink className="tc_FaqComponent_link" to={t("links.convention")}>cette convention</GenericLink> signée par votre direction à l'adresse  <GenericLink className="tc_FaqComponent_link" to={"mailto:" + t("links.contact")}>{t("generic.contact")}</GenericLink>.</div>
+									<div>Vous pouvez vérifier si votre e-mail professionnel est bien reconnu par Tchap  <GenericLink className="tc_FaqComponent_link" to={"/#joinUs"}>en cliquant ici</GenericLink>.</div>
+									<div className="tc_text_nl">Si votre e-mail professionnel n'est pas reconnu par Tchap, vous pouvez en faire la demande en envoyant  <GenericLink className="tc_FaqComponent_link" to={t("links.convention")}>cette convention</GenericLink> signée par votre direction à l'adresse  <GenericLink className="tc_FaqComponent_link" to={"mailto:" + t("links.contact")}>{t("links.contact")}</GenericLink>.</div>
 									<div className="tc_FaqComponent_subtitle">Les partenaires externes</div>
 									<div>Les partenaires externes sont les personnes avec lesquelles vous travaillez qui ne sont pas agents publics.</div>
 									<div>Ils peuvent utiliser Tchap, mais n'ont pas les mêmes droits que les agents publics :</div>

--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -169,7 +169,7 @@ class FaqComponent extends Component {
 										<li>Autres personnes morales de droit public comme les Groupements d'Intérêt Public (GIP)</li>
 									</ul>
 									<div>Vous pouvez vérifier si votre e-mail professionnel est bien reconnu par Tchap  <GenericLink className="tc_FaqComponent_link" to={"/#joinUs"}>ici</GenericLink>.</div>
-									<div className="tc_text_nl">Si votre e-mail professionnel n'est pas reconnu par Tchap, vous pouvez en faire la demande en envoyant  <GenericLink className="tc_FaqComponent_link" to={t("links.convention")}>cette convention</GenericLink> signée par votre direction à l'adresse  <GenericLink className="tc_FaqComponent_link" to={t("links.contact")}>{t("generic.contact")}</GenericLink>.</div>
+									<div className="tc_text_nl">Si votre e-mail professionnel n'est pas reconnu par Tchap, vous pouvez en faire la demande en envoyant  <GenericLink className="tc_FaqComponent_link" to={t("links.convention")}>cette convention</GenericLink> signée par votre direction à l'adresse  <GenericLink className="tc_FaqComponent_link" to={"mailto:" + t("links.contact")}>{t("generic.contact")}</GenericLink>.</div>
 									<div className="tc_FaqComponent_subtitle">Les partenaires externes</div>
 									<div>Les partenaires externes sont les personnes avec lesquelles vous travaillez qui ne sont pas agents publics.</div>
 									<div>Ils peuvent utiliser Tchap, mais n'ont pas les mêmes droits que les agents publics :</div>

--- a/src/pages/home/panels/TestYourEmail.js
+++ b/src/pages/home/panels/TestYourEmail.js
@@ -125,7 +125,7 @@ class TestYourEmail extends Component {
 					<div>Votre administration n'est pas encore présente sur Tchap !</div>
 					<ul className="tc_TestYourEmail_invalid_list">
 						<li>Téléchargez la convention Tchap <a className="tc_TestYourEmail_link" onClick={this._hookProbe}>ici</a></li>
-						<li>Envoyez-la signée par votre direction à <a className="tc_TestYourEmail_link" href={t("links.contact")}>tchap@beta.gouv.fr</a></li>
+						<li>Envoyez-la signée par votre direction à <a className="tc_TestYourEmail_link" href={"mailto:" + t("links.contact")}>tchap@beta.gouv.fr</a></li>
 						<li>L'équipe Tchap se charge de l'ouverture du service à votre administration</li>
 					</ul>
 				</div>

--- a/src/pages/home/panels/TestYourEmail.js
+++ b/src/pages/home/panels/TestYourEmail.js
@@ -124,8 +124,8 @@ class TestYourEmail extends Component {
 				<div className="tc_TestYourEmail_email_text">
 					<div>Votre administration n'est pas encore présente sur Tchap !</div>
 					<ul className="tc_TestYourEmail_invalid_list">
-						<li>Téléchargez la convention Tchap <a className="tc_TestYourEmail_link" onClick={this._hookProbe}>ici</a></li>
-						<li>Envoyez-la signée par votre direction à <a className="tc_TestYourEmail_link" href={"mailto:" + t("links.contact")}>tchap@beta.gouv.fr</a></li>
+						<li>Téléchargez la convention Tchap <a className="tc_TestYourEmail_link" onClick={this._hookProbe}>en cliquant ici</a></li>
+						<li>Envoyez-la signée par votre direction à <a className="tc_TestYourEmail_link" href={"mailto:" + t("links.contact")}>{t("links.contact")}</a></li>
 						<li>L'équipe Tchap se charge de l'ouverture du service à votre administration</li>
 					</ul>
 				</div>
@@ -135,7 +135,7 @@ class TestYourEmail extends Component {
 		return (
 			<Container maxWidth="lg" className="simple_container">
 				<div className="tc_TestYourEmail_label">Votre administration est-elle déjà sur Tchap ?</div>
-				
+
 					<FormControl variant="outlined" size="small">
 						<InputLabel htmlFor="test-your-email" className="tc_TestYourEmail_input_label">Testez votre adresse email professionnelle</InputLabel>
 						<OutlinedInput
@@ -157,7 +157,7 @@ class TestYourEmail extends Component {
 						Vérifier
 					</Button>
 					{ renderBlock }
-				
+
 			</Container>
 		);
 	}


### PR DESCRIPTION
close #76 

Sans le mailto le lien ne marche pas est devient : https://tchap.beta.gouv.fr/tchap@beta.gouv.fr