### PR TITLE
Fix contact link to work on all pages

### DIFF
--- a/src/components/bars/TopBar.js
+++ b/src/components/bars/TopBar.js
@@ -63,7 +63,7 @@ class TopBar extends Component {
 										</li>
 										<li>
 											<a class="fr-link"
-												href="#contact"
+												href="/#contact"
 												data-probe-name="contact"
 												onClick={this._hookProbe}>
 													Contact


### PR DESCRIPTION
Bug : Contact link in the topbar does not work when you are not on the home page (for example the FAQ page).
![image](https://user-images.githubusercontent.com/911434/152977750-734688af-13ab-4aae-9d73-551cb74c15e6.png)

Fixed.