### PR TITLE
FAQ - GESTION DES CLÉS TCHAP (CLÉS DE CHIFFREMENT)

### DIFF
--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -582,7 +582,7 @@ class FaqComponent extends Component {
 											</li>
 											<li>Choisissez un mot de passe (différent de votre mot de passe Tchap) : celui-ci vous sera demandé pour déverrouiller vos messages lors de votre reconnexion.</li>
 											<li>Enregistrez le fichier à un emplacement où vous pourrez le retrouver. Ce fichier s'appelle “Tchap keys” par défaut, mais vous pouvez le renommer.</li>
-											<li>Exportation réussie, vos "Clés Tchap" sont sauvegardées ! Vous pourrez les importer lors de de votre reconnexion pour déverrouiller vos messages.</li>
+											<li>Exportation réussie, vos Clés Tchap sont sauvegardées ! Vous pourrez les importer lors de de votre reconnexion pour déverrouiller vos messages.</li>
 										</ol>
 										<SeeMoreLinks
 											onClick={this._onLocationChange}

--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -582,7 +582,7 @@ class FaqComponent extends Component {
 											</li>
 											<li>Choisissez un mot de passe (différent de votre mot de passe Tchap) : celui-ci vous sera demandé pour déverrouiller vos messages lors de votre reconnexion.</li>
 											<li>Enregistrez le fichier à un emplacement où vous pourrez le retrouver. Ce fichier s'appelle “Tchap keys” par défaut, mais vous pouvez le renommer.</li>
-											<li>Exportation réussie, vos Clés Tchap sont sauvegardées ! Vous pourrez les importer lors de de votre reconnexion pour déverrouiller vos messages.</li>
+											<li>Exportation réussie, vos Clés Tchap sont sauvegardées ! Vous pourrez les importer lors de votre reconnexion pour déverrouiller vos messages.</li>
 										</ol>
 										<SeeMoreLinks
 											onClick={this._onLocationChange}

--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -509,7 +509,7 @@ class FaqComponent extends Component {
 									<title><LinkIcon onClick={this._handleCopyClick} className="tc_FaqComponent_copy_icon" />Comment m'assurer de toujours pouvoir lire mes messages ?</title>
 									<div className="tc_text_nl">
 										<div>
-											Après une nouvelle connexion (lorsque vous entrez votre mail et votre mot de passe), vous ne pouvez pas
+											Après une nouvelle connexion (lorsque vous entrez votre adresse mail professionnelle et votre mot de passe), vous ne pouvez pas
 											lire les messages échangés auparavant.
 										</div>
 										<div>
@@ -519,7 +519,7 @@ class FaqComponent extends Component {
 										<div className="tc_FaqComponent_subtitle">Voici quelques bonnes pratiques pour vous assurer de toujours pouvoir lire vos messages :</div>
 										<div className="tc_FaqComponent_subtitle">Evitez de vous déconnecter de Tchap</div>
 										<div>
-											<span className="tc_text_b">Votre mobile</span> garde votre connexion automatiquement, même lorsque vous fermez l'application ou éteignez votre téléphone
+											<span className="tc_text_b">Votre téléphone mobile</span> garde automatiquement votre connexion, même lorsque vous l'éteignez ou fermez l'application Tchap.
 										</div>
 										<div>
 											<span className="tc_text_b">Votre navigateur web</span> provoque peut-être la déconnexion automatique de Tchap lorsque vous le fermez :
@@ -543,7 +543,7 @@ class FaqComponent extends Component {
 
 										<div className="tc_FaqComponent_subtitle">Sauvegardez manuellement vos Clés Tchap (clés de chiffrement) avant toute déconnexion</div>
 										<div>
-											Si vous savez que vous allez vous déconnecter, sauvegarder vos Clés Tchap (clés de chiffrement) vous permettra déverrouiller vos messages lors de votre reconnexion.
+											Si vous envisagez de vous déconnecter, sauvegarder vos Clés Tchap vous permettra déverrouiller vos messages lors de votre reconnexion.
 										</div>
 										<SeeMoreLinks
 											onClick={this._onLocationChange}
@@ -582,7 +582,7 @@ class FaqComponent extends Component {
 											</li>
 											<li>Choisissez un mot de passe (différent de votre mot de passe Tchap) : celui-ci vous sera demandé pour déverrouiller vos messages lors de votre reconnexion.</li>
 											<li>Enregistrez le fichier à un emplacement où vous pourrez le retrouver. Ce fichier s'appelle “Tchap keys” par défaut, mais vous pouvez le renommer.</li>
-											<li>C'est bon, vos clés Tchap sont sauvegardées ! Vous pourrez les importer lors de de votre reconnexion pour déverrouiller vos messages.</li>
+											<li>Exportation réussie, vos "Clés Tchap" sont sauvegardées ! Vous pourrez les importer lors de de votre reconnexion pour déverrouiller vos messages.</li>
 										</ol>
 										<SeeMoreLinks
 											onClick={this._onLocationChange}
@@ -617,7 +617,7 @@ class FaqComponent extends Component {
 											</li>
 											<li>Sélectionnez le fichier que vous avez préalablement sauvegardé. Par défaut, ce fichier s'appelle “Tchap keys”.</li>
 											<li>Entrez le mot de passe que vous avez choisi au moment de la sauvegarde.</li>
-											<li>C'est bon, vos messages sont déverrouillés et de nouveau lisibles .</li>
+											<li>Importation réussie, vos messages sont déverrouillés et de nouveau lisibles.</li>
 										</ol>
 									</div>
 								</GenericAccordion>
@@ -625,7 +625,7 @@ class FaqComponent extends Component {
 									<title><LinkIcon onClick={this._handleCopyClick} className="tc_FaqComponent_copy_icon" />Pourquoi mes messages sont-ils verrouillés ? </title>
 									<div className="tc_text_nl">
 										<div>
-											Après une nouvelle connexion (lorsque vous entrez votre mail et votre mot de passe), vous ne pouvez pas lire les messages échangés auparavant.
+											Après une nouvelle connexion (lorsque vous entrez votre adresse mail professionnelle et votre mot de passe), vous ne pouvez pas lire les messages échangés auparavant.
 										</div>
 										<div>
 											C'est une mesure de sécurité : si une personne vole vos identifiants et se connecte à votre place, il lui est ainsi impossible de lire vos messages parce qu'ils sont verrouillés.


### PR DESCRIPTION
**GESTION DES CLÉS TCHAP (CLÉS DE CHIFFREMENT)**

Au total, 35 modifications effectuées afin d'harmoniser le contenu de la FAQ avec celui des messages enregistrés dans CRISP.

A consulter dans l'onglet "FAQ" du tableau suivant : https://docs.google.com/spreadsheets/d/18eiiLCPXvv6xCZM3sdax4KCsYsBHTjnd/edit?usp=sharing&ouid=101075634191255878179&rtpof=true&sd=true