### PR TITLE
FAQ - "DÉCHIFFREMENT IMPOSSIBLE" DE MES MESSAGES : COMMENT Y REMÉDIER ?

### DIFF
--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -689,13 +689,13 @@ class FaqComponent extends Component {
 												<span className="tc_text_b">Allez dans les Paramètres</span> de Tchap :
 												<ul>
 													<li>
-														Sur ordinateur, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importer les clés de chiffrement de bout en bout”.
+														Sur ordinateur, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importez vos Clés Tchap depuis le fichier sauvegardé”.
 													</li>
 													<li>
-														Sur Android, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importer les clés des conversations”.
+														Sur Android, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importer les Clés Tchap”.
 													</li>
 													<li>
-														Sur iOS, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importer les clés de chiffrement de bout en bout”.
+														Sur iOS, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importer les Clés Tchap”.
 													</li>
 												</ul>
 											</li>

--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -692,10 +692,10 @@ class FaqComponent extends Component {
 														Sur ordinateur, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importez vos Clés Tchap depuis le fichier sauvegardé”.
 													</li>
 													<li>
-														Sur Android, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importer les Clés Tchap”.
+														Sur Android, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importer les clés de chiffrement des conversations”.
 													</li>
 													<li>
-														Sur iOS, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importer les Clés Tchap”.
+														Sur iOS, allez dans Paramètres > Sécurité & Vie Privée et cliquez sur “Importer les Clés”.
 													</li>
 												</ul>
 											</li>


### PR DESCRIPTION
**"DÉCHIFFREMENT IMPOSSIBLE" DE MES MESSAGES : COMMENT Y REMÉDIER ?**

Au total, 35 modifications effectuées afin d'harmoniser le contenu de la FAQ avec celui des messages enregistrés dans CRISP.

A consulter dans l'onglet "FAQ" du tableau suivant : https://docs.google.com/spreadsheets/d/18eiiLCPXvv6xCZM3sdax4KCsYsBHTjnd/edit?usp=sharing&ouid=101075634191255878179&rtpof=true&sd=true