### PR TITLE
Show csv invitation in faq only on mobiles

### DIFF
--- a/res/css/pages/faq/FaqComponent.scss
+++ b/res/css/pages/faq/FaqComponent.scss
@@ -1,11 +1,24 @@
 .tc_FaqComponent {
   padding-bottom: 50px;
+  ul {
+    margin: 0px;
+  }
+  ul li {
+    margin-left: 8px;
+  }
+  ul li button {
+    margin: 0px;
+  }
   li {
     margin-bottom: 4px;
   }
   div {
     line-height: $font-line-height-24;
   }
+}
+
+.tc_FaqComponent_tabs {
+  margin: 20px 0px;
 }
 
 .tc_FaqComponent_menu_title {
@@ -84,6 +97,10 @@
 .tc_FaqComponent_border {
   border: 1px solid $color-text-darkgrey;
   border-radius: 3px;
+}
+
+.tc_FaqComponent_tabs__list {
+  margin-left: 10px;
 }
 
 @media (max-width: 650px) {

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -3,47 +3,57 @@ import PropTypes from 'prop-types';
 import Grid from "@mui/material/Grid";
 
 const TabsComponent = ({
+    id,
     tabs,
     tabPanels
 }) => {
     return (
         <div className="fr-tabs tc_FaqComponent_tabs">
             <ul className="fr-tabs__list" role="tablist">
-                {tabs.map((tab, index) => (
-                    <li key={tab.id} role="presentation">
-                        <button
-                            aria-controls={`${tab.id}-panel`}
-                            aria-selected={index === 0 ? "true" : "false"}
-                            className="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left"
-                            id={tab.id}
-                            role="tab"
-                            tabIndex={index === 0 ? "0" : "-1"}
-                        >
-                            {tab.label}
-                        </button>
-                    </li>
-                ))}
+                {tabs.map((tab, index) => {
+                    const tabId = `${tab.id}${id}`;
+
+                    return (
+                        <li key={tabId} role="presentation">
+                            <button
+                                aria-controls={`${tabId}-panel`}
+                                aria-selected={index === 0 ? "true" : "false"}
+                                className="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left"
+                                id={tabId}
+                                role="tab"
+                                tabIndex={index === 0 ? "0" : "-1"}
+                            >
+                                {tab.label}
+                            </button>
+                        </li>
+                    )
+                })}
             </ul>
 
-            {tabs.map(tab => (
-                <div
-                    aria-labelledby={tab.id}
-                    className="fr-tabs__panel fr-tabs__panel--selected"
-                    id={`${tab.id}-panel`}
-                    key={tab.id}
-                    role="tabpanel"
-                    tabIndex="0"
-                >
-                    <Grid item xl={6}>
-                        {tabPanels[tab.id]}
-                    </Grid>
-                </div>
-            ))}
+            {tabs.map(tab => {
+                const tabId = `${tab.id}${id}`;
+
+                return (
+                    <div
+                        aria-labelledby={tabId}
+                        className="fr-tabs__panel fr-tabs__panel--selected"
+                        id={`${tabId}-panel`}
+                        key={tabId}
+                        role="tabpanel"
+                        tabIndex="0"
+                    >
+                        <Grid item xl={6}>
+                            {tabPanels[tab.id]}
+                        </Grid>
+                    </div>
+                )
+            })}
         </div>
     )
 }
 
 TabsComponent.propTypes = {
+    id: PropTypes.string.isRequired,
     tabs: PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.string.isRequired,
         label: PropTypes.string.isRequired,

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Grid from "@mui/material/Grid";
+
+const TabsComponent = ({
+    tabs,
+    tabPanels
+}) => {
+    return (
+        <div className="fr-tabs tc_FaqComponent_tabs">
+            <ul className="fr-tabs__list" role="tablist">
+                {tabs.map((tab, index) => (
+                    <li key={tab.id} role="presentation">
+                        <button
+                            aria-controls={`${tab.id}-panel`}
+                            aria-selected={index === 0 ? "true" : "false"}
+                            className="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left"
+                            id={tab.id}
+                            role="tab"
+                            tabIndex={index === 0 ? "0" : "-1"}
+                        >
+                            {tab.label}
+                        </button>
+                    </li>
+                ))}
+            </ul>
+
+            {tabs.map(tab => (
+                <div
+                    aria-labelledby={tab.id}
+                    className="fr-tabs__panel fr-tabs__panel--selected"
+                    id={`${tab.id}-panel`}
+                    key={tab.id}
+                    role="tabpanel"
+                    tabIndex="0"
+                >
+                    <Grid item xl={6}>
+                        {tabPanels[tab.id]}
+                    </Grid>
+                </div>
+            ))}
+        </div>
+    )
+}
+
+TabsComponent.propTypes = {
+    tabs: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+    }).isRequired).isRequired,
+    tabPanels: PropTypes.object.isRequired,
+}
+
+export const Tabs = TabsComponent;

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -42,7 +42,7 @@ const TabsComponent = ({
                         role="tabpanel"
                         tabIndex="0"
                     >
-                        <Grid item xl={6}>
+                        <Grid item>
                             {tabPanels[tab.id]}
                         </Grid>
                     </div>

--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -71,6 +71,7 @@ class FaqComponent extends Component {
 		this._onChange = this._onChange.bind(this);
 		this._onLocationChange = this._onLocationChange.bind(this);
 		this._handleCopyClick = this._handleCopyClick.bind(this);
+		this.detectIfMobileDevice = this.detectIfMobileDevice.bind(this);
 	}
 
 	componentDidMount() {
@@ -141,6 +142,11 @@ class FaqComponent extends Component {
 			onChange: () => this._onChange(id),
 			className: "tc_FaqComponent_Accordion"
 		};
+	}
+
+	detectIfMobileDevice() {
+		return navigator?.userAgentData?.mobile
+		// return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 	}
 
 	render() {
@@ -362,6 +368,7 @@ class FaqComponent extends Component {
 									<title><LinkIcon onClick={this._handleCopyClick} className="tc_FaqComponent_copy_icon" />Comment envoyer un nouveau message direct ?</title>
 									<div className="tc_text_nl">L'annuaire intégré vous permet d'entrer en contact direct avec l'ensemble des membres de Tchap.</div>
 									<div className="tc_text_nl">Pour démarrer une nouvelle conversation :</div>
+
 									<ul className="tc_list_decimal">
 										<li>
 											<Grid container className="tc_FaqComponent_grid">
@@ -422,16 +429,31 @@ class FaqComponent extends Component {
 									<title><LinkIcon onClick={this._handleCopyClick} className="tc_FaqComponent_copy_icon" />Comment rejoindre un salon ?</title>
 									<div className="tc_text_nl"><span className="tc_text_b">Pour rejoindre un salon privé</span>, vous devez recevoir une invitation de la part d’un de ses administrateurs.</div>
 									<div className="tc_text_nl"><span className="tc_text_b">Pour trouver et rejoindre un forum</span>, vous pouvez rechercher par mots clés :</div>
-									<Grid container className="tc_FaqComponent_grid">
-										<Grid item xl={6}>
-											<div className="tc_text_nl"><span className="tc_text_b">Sur mobile</span>, rendez-vous dans l'onglet des salons (#), cliquez sur le bouton "#+" et sélectionnez “Accéder à un forum”.</div>
-											<img src={require("images/pem/create_room_mobile.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon mobile" width="485"/>
-										</Grid>
-										<Grid item xl={6}>
-											<div className="tc_text_nl"><span className="tc_text_b">Sur le web</span>, cliquez sur le bouton “+” de la section “salons”.</div>
-											<img src={require("images/pem/create_room_web.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon web"/>					
-										</Grid>
-									</Grid>
+									
+									<div className="fr-tabs">
+										<ul className="fr-tabs__list" role="tablist" aria-label="[A modifier | nom du système d'onglet]">
+											<li role="presentation">
+												<button id="tabpanel-404" className="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabIndex="0" role="tab" aria-selected="true" aria-controls="tabpanel-404-panel">Mobile</button>
+											</li>
+											<li role="presentation">
+												<button id="tabpanel-405" className="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabIndex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-405-panel">Web</button>
+											</li>
+										</ul>
+										<div id="tabpanel-404-panel" className="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-404" tabIndex="0">
+											{/* <p>Contenu 1</p> */}
+											<Grid item xl={6}>
+												<div className="tc_text_nl"><span className="tc_text_b">Sur mobile</span>, rendez-vous dans l'onglet des salons (#), cliquez sur le bouton "#+" et sélectionnez “Accéder à un forum”.</div>
+												<img src={require("images/pem/create_room_mobile.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon mobile" width="485"/>
+											</Grid>
+										</div>
+										<div id="tabpanel-405-panel" className="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-405" tabIndex="0">
+											{/* <p>Contenu 2</p> */}
+											<Grid item xl={6}>
+												<div className="tc_text_nl"><span className="tc_text_b">Sur le web</span>, cliquez sur le bouton “+” de la section “salons”.</div>
+												<img src={require("images/pem/create_room_web.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon web"/>					
+											</Grid>
+										</div>
+									</div>
 									<div className="tc_text_nl">Vous pouvez ensuite parcourir la liste des salons forums, ou procéder à une recherche par mots clés.</div>
 									<div className="tc_text_nl">Il est également possible de rejoindre un forum sur invitation d'un membre.</div>
 									<SeeMoreLinks
@@ -706,7 +728,7 @@ class FaqComponent extends Component {
 											dans ce cas, allez dans les réglages du navigateur et autorisez la conservation des données de navigation pour Tchap. Une intervention de vos services informatiques peut être nécessaire.
 										</div>
 										<div>
-											<span class="tc_text_i">Si vous souhaitez mettre Tchap “en pause” (lors de vos congés par exemple), vous pouvez désactiver les notifications sans avoir à vous déconnecter.</span>
+											<span className="tc_text_i">Si vous souhaitez mettre Tchap “en pause” (lors de vos congés par exemple), vous pouvez désactiver les notifications sans avoir à vous déconnecter.</span>
 										</div>
 										<div className="tc_FaqComponent_subtitle">Gardez au moins deux appareils connectés à Tchap</div>
 										<div>
@@ -738,7 +760,7 @@ class FaqComponent extends Component {
 									<div className="tc_text_nl">
 										<div className="tc_FaqComponent_subtitle">Pour sauvegarder vos clés :</div>
 										<div>
-										<span class="tc_text_i">(Action à effectuer préalablement à une déconnexion ou une réinitialisation de mot de passe pour ne pas perdre accès à vos messages)</span>
+										<span className="tc_text_i">(Action à effectuer préalablement à une déconnexion ou une réinitialisation de mot de passe pour ne pas perdre accès à vos messages)</span>
 										</div>
 										<ol>
 											<li>Rendez-vous dans les paramètres de Tchap :

--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -1,5 +1,4 @@
 import { Component } from "react";
-import PropTypes from "prop-types";
 import { routerHOC } from "utils/HOC/ReactRouterHOC";
 import { t } from "react-i18nify";
 import Container from "@mui/material/Container";
@@ -11,6 +10,7 @@ import BottomBar from "components/bars/BottomBar";
 import GenericAccordion from "components/accordion/GenericAccordion";
 import GenericLink from "components/GenericLink";
 import SeeMoreLinks from "components/SeeMoreLinks";
+import { Tabs } from "components/tabs/Tabs";
 
 import "styles/pages/faq/FaqComponent.scss";
 
@@ -71,7 +71,6 @@ class FaqComponent extends Component {
 		this._onChange = this._onChange.bind(this);
 		this._onLocationChange = this._onLocationChange.bind(this);
 		this._handleCopyClick = this._handleCopyClick.bind(this);
-		this.detectIfMobileDevice = this.detectIfMobileDevice.bind(this);
 	}
 
 	componentDidMount() {
@@ -142,11 +141,6 @@ class FaqComponent extends Component {
 			onChange: () => this._onChange(id),
 			className: "tc_FaqComponent_Accordion"
 		};
-	}
-
-	detectIfMobileDevice() {
-		return navigator?.userAgentData?.mobile
-		// return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 	}
 
 	render() {
@@ -368,7 +362,6 @@ class FaqComponent extends Component {
 									<title><LinkIcon onClick={this._handleCopyClick} className="tc_FaqComponent_copy_icon" />Comment envoyer un nouveau message direct ?</title>
 									<div className="tc_text_nl">L'annuaire intégré vous permet d'entrer en contact direct avec l'ensemble des membres de Tchap.</div>
 									<div className="tc_text_nl">Pour démarrer une nouvelle conversation :</div>
-
 									<ul className="tc_list_decimal">
 										<li>
 											<Grid container className="tc_FaqComponent_grid">
@@ -429,31 +422,28 @@ class FaqComponent extends Component {
 									<title><LinkIcon onClick={this._handleCopyClick} className="tc_FaqComponent_copy_icon" />Comment rejoindre un salon ?</title>
 									<div className="tc_text_nl"><span className="tc_text_b">Pour rejoindre un salon privé</span>, vous devez recevoir une invitation de la part d’un de ses administrateurs.</div>
 									<div className="tc_text_nl"><span className="tc_text_b">Pour trouver et rejoindre un forum</span>, vous pouvez rechercher par mots clés :</div>
-									
-									<div className="fr-tabs">
-										<ul className="fr-tabs__list" role="tablist" aria-label="[A modifier | nom du système d'onglet]">
-											<li role="presentation">
-												<button id="tabpanel-404" className="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabIndex="0" role="tab" aria-selected="true" aria-controls="tabpanel-404-panel">Mobile</button>
-											</li>
-											<li role="presentation">
-												<button id="tabpanel-405" className="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabIndex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-405-panel">Web</button>
-											</li>
-										</ul>
-										<div id="tabpanel-404-panel" className="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-404" tabIndex="0">
-											{/* <p>Contenu 1</p> */}
-											<Grid item xl={6}>
-												<div className="tc_text_nl"><span className="tc_text_b">Sur mobile</span>, rendez-vous dans l'onglet des salons (#), cliquez sur le bouton "#+" et sélectionnez “Accéder à un forum”.</div>
-												<img src={require("images/pem/create_room_mobile.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon mobile" width="485"/>
-											</Grid>
-										</div>
-										<div id="tabpanel-405-panel" className="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-405" tabIndex="0">
-											{/* <p>Contenu 2</p> */}
-											<Grid item xl={6}>
-												<div className="tc_text_nl"><span className="tc_text_b">Sur le web</span>, cliquez sur le bouton “+” de la section “salons”.</div>
-												<img src={require("images/pem/create_room_web.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon web"/>					
-											</Grid>
-										</div>
-									</div>
+
+									<Tabs
+										tabs={[
+											{ id: 'mobile', label: 'Mobile' },
+											{ id: 'web', label: 'Web' }
+										]}
+										tabPanels={{
+											mobile: (
+												<>
+													<div className="tc_text_nl">Rendez-vous dans l'onglet des salons (#), cliquez sur le bouton "#+" et sélectionnez “Accéder à un forum”.</div>
+													<img src={require("images/pem/create_room_mobile.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon mobile" width="485"/>
+												</>
+											),
+											web: (
+												<>
+													<div className="tc_text_nl">Cliquez sur le bouton “+” de la section “salons”.</div>
+													<img src={require("images/pem/create_room_web.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon web"/>
+												</>
+											)
+										}}
+									/>
+
 									<div className="tc_text_nl">Vous pouvez ensuite parcourir la liste des salons forums, ou procéder à une recherche par mots clés.</div>
 									<div className="tc_text_nl">Il est également possible de rejoindre un forum sur invitation d'un membre.</div>
 									<SeeMoreLinks

--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -424,6 +424,7 @@ class FaqComponent extends Component {
 									<div className="tc_text_nl"><span className="tc_text_b">Pour trouver et rejoindre un forum</span>, vous pouvez rechercher par mots clés :</div>
 
 									<Tabs
+										id="tcq03_006"
 										tabs={[
 											{ id: 'mobile', label: 'Mobile' },
 											{ id: 'web', label: 'Web' }
@@ -614,13 +615,65 @@ class FaqComponent extends Component {
 									<title><LinkIcon onClick={this._handleCopyClick} className="tc_FaqComponent_copy_icon" />Comment inviter des participants à rejoindre un salon ?</title>
 									<div className="tc_text_nl">Pour les salons privés, seuls les administrateurs peuvent inviter des membres à rejoindre la conversation.</div>
 									<div className="tc_text_nl">Pour les salons publics, l'invitation n'est pas indispensable mais peut être utilisée pour inviter des membres à rejoindre le salon.</div>
-									<div className="tc_text_nl">Pour envoyer des invitations, rendez-vous dans les paramètres du salon, et cliquez sur "inviter dans ce salon". Plusieurs possibilités s'offrent alors à vous :</div>
+
+									<Tabs
+										id="tcq04_003"
+										tabs={[
+											{ id: 'mobile_tcq04_003', label: 'Mobile' },
+											{ id: 'web_tcq04_003', label: 'Web' }
+										]}
+										tabPanels={{
+											mobile_tcq04_003: (
+												<>
+													<div className="tc_text_nl">Pour envoyer des invitations, rendez-vous dans les paramètres du salon, et cliquez sur "inviter dans ce salon". Plusieurs possibilités s'offrent alors à vous :</div>
+													<ul>
+														<li>Inviter les membres un par un en les recherchant dans l'annuaire des membres de Tchap.</li>
+														<li>Inviter plusieurs membres à la fois en important un fichier .txt ou .csv contenant les adresses e-mail des interlocuteurs visés.</li>
+													</ul>
+													<div className="tc_text_nl">Vous pouvez également partager le lien d'un salon pour inviter des membres à le rejoindre.</div>
+													<div className="tc_text_nl">S'il s'agit d'un salon privé, assurez-vous au préalable d'avoir autorisé l'accès au salon par lien (dans les paramètres du salon). Attention : si cette option est activée, chaque personne disposant du lien pourra accéder au salon privé.</div>
+												</>
+											),
+											web_tcq04_003: (
+												<>
+													<div className="tc_text_nl">Pour envoyer des invitations, rendez-vous dans les paramètres du salon, et cliquez sur "inviter dans ce salon". Vous pouvez alors inviter les membres un par un en les recherchant dans l'annuaire des membres de Tchap.</div>
+													<div className="tc_text_nl">Vous pouvez également partager le lien d'un salon pour inviter des membres à le rejoindre.</div>
+													<div className="tc_text_nl">S'il s'agit d'un salon privé, assurez-vous au préalable d'avoir autorisé l'accès au salon par lien (dans les paramètres du salon). Attention : si cette option est activée, chaque personne disposant du lien pourra accéder au salon privé.</div>
+												</>
+											)
+										}}
+									/>
+
+									{/*
+									<Tabs
+										tabs={[
+											{ id: 'mobile', label: 'Mobile' },
+											{ id: 'web', label: 'Web' }
+										]}
+										tabPanels={{
+											mobile: (
+												<>
+													<div className="tc_text_nl">Rendez-vous dans l'onglet des salons (#), cliquez sur le bouton "#+" et sélectionnez “Accéder à un forum”.</div>
+													<img src={require("images/pem/create_room_mobile.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon mobile" width="485"/>
+												</>
+											),
+											web: (
+												<>
+													<div className="tc_text_nl">Cliquez sur le bouton “+” de la section “salons”.</div>
+													<img src={require("images/pem/create_room_web.png")} className="tc_FaqComponent_wimg_mobile" alt="Création salon web"/>
+												</>
+											)
+										}}
+									/>
+									 */}
+
+									{/* <div className="tc_text_nl">Pour envoyer des invitations, rendez-vous dans les paramètres du salon, et cliquez sur "inviter dans ce salon". Plusieurs possibilités s'offrent alors à vous :</div>
 									<ul>
 										<li>Inviter les membres un par un en les recherchant dans l'annuaire des membres de Tchap</li>
 										<li>Inviter plusieurs membres à la fois en important un fichier .txt ou .csv contenant les adresses e-mail des interlocuteurs visés.</li>
 									</ul>
 									<div className="tc_text_nl">Vous pouvez également partager le lien d'un salon pour inviter des membres à le rejoindre.</div>
-									<div className="tc_text_nl">S'il s'agit d'un salon privé, assurez-vous au préalable d'avoir autorisé l'accès au salon par lien (dans les paramètres du salon). Attention : si cette option est activée, chaque personne disposant du lien pourra accéder au salon privé.</div>
+									<div className="tc_text_nl">S'il s'agit d'un salon privé, assurez-vous au préalable d'avoir autorisé l'accès au salon par lien (dans les paramètres du salon). Attention : si cette option est activée, chaque personne disposant du lien pourra accéder au salon privé.</div> */}
 									<SeeMoreLinks
 										onClick={this._onLocationChange}
 										links={[


### PR DESCRIPTION
In FAQ, web users can no longer invite several members at once by importing .txt of .csv files. This PR variabilize the answer by adding tabs for web and mobile options for this question. Only the mobile option now shows the csv info.
Cf. https://github.com/tchapgouv/tchap-landing-page/issues/154

<img width="1161" alt="Screenshot 2023-01-30 at 17 10 29" src="https://user-images.githubusercontent.com/6305268/215531215-182d5e6d-7d01-4b72-857f-f84e1788b978.png">
<img width="1161" alt="Screenshot 2023-01-30 at 17 10 35" src="https://user-images.githubusercontent.com/6305268/215531243-f2f9302d-e73d-4e9a-9bf4-bd431ea435a3.png">
