### PR TITLE
Remove .csv and .txt reference in invitation question

### DIFF
--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -42,7 +42,7 @@ const TabsComponent = ({
                         role="tabpanel"
                         tabIndex="0"
                     >
-                        <Grid item xl={6}>
+                        <Grid item>
                             {tabPanels[tab.id]}
                         </Grid>
                     </div>

--- a/src/pages/faq/FaqComponent.js
+++ b/src/pages/faq/FaqComponent.js
@@ -615,11 +615,7 @@ class FaqComponent extends Component {
 									<title><LinkIcon onClick={this._handleCopyClick} className="tc_FaqComponent_copy_icon" />Comment inviter des participants à rejoindre un salon ?</title>
 									<div className="tc_text_nl">Pour les salons privés, seuls les administrateurs peuvent inviter des membres à rejoindre la conversation.</div>
 									<div className="tc_text_nl">Pour les salons publics, l'invitation n'est pas indispensable mais peut être utilisée pour inviter des membres à rejoindre le salon.</div>
-									<div className="tc_text_nl">Pour envoyer des invitations, rendez-vous dans les paramètres du salon, et cliquez sur "inviter dans ce salon". Plusieurs possibilités s'offrent alors à vous :</div>
-									<ul>
-										<li>Inviter les membres un par un en les recherchant dans l'annuaire des membres de Tchap</li>
-										<li>Inviter plusieurs membres à la fois en important un fichier .txt ou .csv contenant les adresses e-mail des interlocuteurs visés.</li>
-									</ul>
+									<div className="tc_text_nl">Pour envoyer des invitations, rendez-vous dans les paramètres du salon, et cliquez sur "inviter dans ce salon". Vous pouvez alors inviter les membres un par un en les recherchant dans l'annuaire des membres de Tchap.</div>
 									<div className="tc_text_nl">Vous pouvez également partager le lien d'un salon pour inviter des membres à le rejoindre.</div>
 									<div className="tc_text_nl">S'il s'agit d'un salon privé, assurez-vous au préalable d'avoir autorisé l'accès au salon par lien (dans les paramètres du salon). Attention : si cette option est activée, chaque personne disposant du lien pourra accéder au salon privé.</div>
 									<SeeMoreLinks


### PR DESCRIPTION
In FAQ, web users can no longer invite several members at once by importing .txt of .csv files. This PR removes the .csv and .txt reference in the invitation answer.
Cf. https://github.com/tchapgouv/tchap-landing-page/issues/154

<img width="1170" alt="Screenshot 2023-02-01 at 15 23 22" src="https://user-images.githubusercontent.com/6305268/216069459-3248ee06-a982-4813-ad9b-e600d74c561f.png">
