### PR TITLE
Update landing content

### DIFF
--- a/src/components/bars/BottomBar.js
+++ b/src/components/bars/BottomBar.js
@@ -34,12 +34,12 @@ class BottomBar extends Component {
 							</p>
 							<ul className="fr-footer__content-list">
 								<li className="fr-footer__content-item">
-									<a className="fr-footer__content-link" href="https://www.tchap.gouv.fr" data-probe-name="tchap-app" onClick={this._hookProbe}>
+									<a className="fr-footer__content-link" href="https://www.tchap.gouv.fr" data-probe-name="tchap-app" target="_blank" onClick={this._hookProbe}>
 										Utiliser Tchap
 									</a>
 								</li>
 								<li className="fr-footer__content-item">
-									<a className="fr-footer__content-link" href="https://github.com/tchapgouv" data-probe-name="github" onClick={this._hookProbe}>
+									<a className="fr-footer__content-link" href="https://github.com/tchapgouv" data-probe-name="github" target="_blank" onClick={this._hookProbe}>
 										Le code de Tchap sur Github
 									</a>
 								</li>
@@ -49,12 +49,12 @@ class BottomBar extends Component {
 									</a>
 								</li>
 								<li className="fr-footer__content-item">
-									<a className="fr-footer__content-link" href="https://beta.gouv.fr" data-probe-name="betagouv" onClick={this._hookProbe}>
+									<a className="fr-footer__content-link" href="https://beta.gouv.fr" data-probe-name="betagouv" target="_blank" onClick={this._hookProbe}>
 										beta.gouv.fr
 									</a>
 								</li>
 								<li className="fr-footer__content-item">
-									<a className="fr-footer__content-link" href="https://matrix.org/" data-probe-name="matrix" onClick={this._hookProbe}>
+									<a className="fr-footer__content-link" href="https://matrix.org/" data-probe-name="matrix" target="_blank" onClick={this._hookProbe}>
 										matrix.org
 									</a>
 								</li>
@@ -79,6 +79,11 @@ class BottomBar extends Component {
 							<li className="fr-footer__bottom-item">
 								<a className="fr-footer__bottom-link" href="/cgu" data-probe-name="terms-and-conditions" onClick={this._hookProbe}>
 									Conditions d'utilisation
+								</a>
+							</li>
+							<li className="fr-footer__bottom-item">
+								<a className="fr-footer__bottom-link" href="https://stats.tchap.incubateur.net/public/dashboard/8c6560e3-c27a-487b-b242-eb1636912f1a" data-probe-name="stats" target="_blank" onClick={this._hookProbe}>
+									Statistiques
 								</a>
 							</li>
 						</ul>

--- a/src/pages/faq/FaqPasswordReset.js
+++ b/src/pages/faq/FaqPasswordReset.js
@@ -300,7 +300,7 @@ class FaqPasswordReset extends Component {
 						/>
 					<div className="tc_vertical_image_margin" />
 
-					<li>La page « Relevez vos e-mails » s’affiche : allez dans votre boite mail, ouvrez le mail « Changement de mot de passe » et cliquez sur « Réinitialiser mon mot de passe ».</li>
+					<li>La page « Relevez vos adresses mails » s’affiche : allez dans votre boite mail, ouvrez le mail « Changement de mot de passe » et cliquez sur « Réinitialiser mon mot de passe ».</li>
 					
 					<div className="tc_vertical_image_margin" />
 						<div className="tc_align_horizontal">

--- a/src/pages/home/panels/TestYourEmail.js
+++ b/src/pages/home/panels/TestYourEmail.js
@@ -128,7 +128,7 @@ class TestYourEmail extends Component {
 				<div className="tc_TestYourEmail_label">Votre administration est-elle déjà sur Tchap ?</div>
 
 					<FormControl variant="outlined" size="small">
-						<InputLabel htmlFor="test-your-email" className="tc_TestYourEmail_input_label">Testez votre adresse email professionnelle</InputLabel>
+						<InputLabel htmlFor="test-your-email" className="tc_TestYourEmail_input_label">Testez votre adresse mail professionnelle</InputLabel>
 						<OutlinedInput
 							id="test-your-email"
 							className="tc_TestYourEmail_input"
@@ -141,7 +141,7 @@ class TestYourEmail extends Component {
 									{ validateIcon }
 								</InputAdornment>
 							}
-							label="Testez votre adresse email professionnelle"
+							label="Testez votre adresse mail professionnelle"
 						/>
 					</FormControl>
 					<Button variant="contained" size="large" onClick={this.analyzeEmail} className={colorClass}>

--- a/src/pages/home/panels/WelcomePanel.js
+++ b/src/pages/home/panels/WelcomePanel.js
@@ -13,9 +13,9 @@ class WelcomePanel extends Component {
 					<Container maxWidth="lg">
 						<Grid container spacing={3}>
 							<Grid item md={7} xs={12} className="tc_WelcomePanel_block">
-								<h1>Tchap, la messagerie instantanée de confiance de l'Administration</h1>
-								<div className="fr-text--lead">Conçue pour les agents des trois fonctions publiques, pour communiquer facilement en toute sécurité.</div>
-								<div className="fr-text--lead">Utilisée par plus de 260 000 agents publics.</div>
+								<h1>Tchap, la messagerie instantanée de l'Administration</h1>
+								<div className="fr-text--lead">Conçue et gérée par l'Administration française, pour les agents des trois fonctions publiques, pour communiquer facilement en toute sécurité.</div>
+								<div className="fr-text--lead">Utilisée par plus de 400 000 agents publics.</div>
 								<div className="tc_WelcomePanel_content">
 									<WelcomePanelBtns />
 								</div>

--- a/src/pages/privacy-policy/PrivacyPolicy.js
+++ b/src/pages/privacy-policy/PrivacyPolicy.js
@@ -35,7 +35,7 @@ class PrivacyPolicy extends Component {
 								<ul>
 									<li><span className="tc_text_b">Données relatives au profil :</span> prénom, nom, organisation et adresse mail professionnelle (obligatoire), une photographie d’identité (optionnel) ;</li>
 									<li><span className="tc_text_b">Données de contenus du service de messagerie instantanée :</span> message, fichiers, métadonnées ;</li>
-									<li><span className="tc_text_b">Données de contact du répertoire mobile :</span> prénom, nom, email (optionnel et les données ne sont pas importées) ;</li>
+									<li><span className="tc_text_b">Données de contact du répertoire mobile :</span> prénom, nom, adresse mail (optionnel et les données ne sont pas importées) ;</li>
 									<li><span className="tc_text_b">Données de connexion.</span></li>
 								</ul>
 							</div>
@@ -164,13 +164,13 @@ class PrivacyPolicy extends Component {
 									</tr>
 									<tr>
 										<th>Cloud du Ministère de l’Intérieur</th>
-										<td>Hébergement et envoi d’emails</td>
+										<td>Hébergement et envoi d’adresses mails</td>
 										<td>France</td>
 										<td>https://www.numerique.gouv.fr/services/cloud/cloud-interne/</td>
 									</tr>
 									<tr>
 										<th>Crisp</th>
-										<td>Support utilisateurs par email</td>
+										<td>Support utilisateurs par adresse mail</td>
 										<td>Pays Bas et Allemagne</td>
 										<td>https://crisp.chat/fr/</td>
 									</tr>
@@ -205,7 +205,7 @@ class PrivacyPolicy extends Component {
 							<div>Lorsque vous autorisez cet accès, Tchap l’utilise de deux manières :</div>
 							<br/>
 							<ul>
-								<li>Tchap parcourt les adresses emails de vos contacts pour découvrir d’autres Utilisateurs et Utilisatrices inscrits sur Tchap. Ces Utilisateurs et Utilisatrices sont listés dans la section ‘Contacts’ de l’Application. Ils vous sont proposés également lorsque vous souhaitez inviter des nouveaux membres à un salon. Aucune adresse email n’est stockée sur les serveurs ;</li>
+								<li>Tchap parcourt les adresses mails de vos contacts pour découvrir d’autres Utilisateurs et Utilisatrices inscrits sur Tchap. Ces Utilisateurs et Utilisatrices sont listés dans la section ‘Contacts’ de l’Application. Ils vous sont proposés également lorsque vous souhaitez inviter des nouveaux membres à un salon. Aucune adresse mail n’est stockée sur les serveurs ;</li>
 								<li>Lorsque vous souhaitez inviter des nouvelles personnes à rejoindre Tchap, les coordonnées de vos contacts locaux vous sont proposées.</li>
 							</ul>
 						</div>


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-landing-page/issues/169


- [x] Change wording:

Before:

<img width="672" alt="Capture d’écran 2023-06-07 à 11 04 41" src="https://github.com/tchapgouv/tchap-landing-page/assets/6305268/ffbb23ab-5d59-4d66-8de1-55877fcc7e8b">

After:

<img width="682" alt="Capture d’écran 2023-06-07 à 10 55 11" src="https://github.com/tchapgouv/tchap-landing-page/assets/6305268/b7217eab-97c1-4db6-8621-0a50aa32749f">


- [x] Change "email" to "adresse mail":

<img width="463" alt="Capture d’écran 2023-06-07 à 10 55 46" src="https://github.com/tchapgouv/tchap-landing-page/assets/6305268/95aad1d7-2b1a-4ed3-9f73-cb00cec38bb0">
<img width="871" alt="Capture d’écran 2023-06-07 à 10 55 53" src="https://github.com/tchapgouv/tchap-landing-page/assets/6305268/d03f2c92-3cda-44aa-9550-5e0bd4c4095f">
<img width="1185" alt="Capture d’écran 2023-06-07 à 10 57 30" src="https://github.com/tchapgouv/tchap-landing-page/assets/6305268/656f7c09-0db3-4264-81d1-cf17fe2e303b">


- [x] Add a Stats tab that redirects to https://stats.tchap.incubateur.net/public/dashboard/8c6560e3-c27a-487b-b242-eb1636912f1a:

<img width="792" alt="Capture d’écran 2023-06-07 à 10 56 21" src="https://github.com/tchapgouv/tchap-landing-page/assets/6305268/255c2d5b-c04f-4e71-8ea5-b4fdc23ee10e">


- [x] NB: additionally, this PR adds target="_blank" to redirections that leave the landing page.